### PR TITLE
Bluetooth: rfcomm: reinstate commented out folders

### DIFF
--- a/net/bluetooth/Makefile
+++ b/net/bluetooth/Makefile
@@ -3,10 +3,10 @@
 #
 
 obj-$(CONFIG_BT)	+= bluetooth.o
-#obj-$(CONFIG_BT_RFCOMM)	+= rfcomm/
-#obj-$(CONFIG_BT_BNEP)	+= bnep/
+obj-$(CONFIG_BT_RFCOMM)	+= rfcomm/
+obj-$(CONFIG_BT_BNEP)	+= bnep/
 obj-$(CONFIG_BT_CMTP)	+= cmtp/
-#obj-$(CONFIG_BT_HIDP)	+= hidp/
+obj-$(CONFIG_BT_HIDP)	+= hidp/
 obj-$(CONFIG_BT_6LOWPAN) += bluetooth_6lowpan.o
 
 bluetooth_6lowpan-y := 6lowpan.o


### PR DESCRIPTION
This commit restores the rfcomm kernel functionality that was otherwise unavailable after setting the following kernel flags:

CONFIG_BT_RFCOMM=y
CONFIG_BT_RFCOMM_TTY=y