### PR TITLE
Force OEM unlock

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -50,6 +50,7 @@ static int __init proc_cmdline_init(void)
 	strcpy(updated_command_line, saved_command_line);
 
 	proc_cmdline_set("androidboot.verifiedbootstate", "green");
+	proc_cmdline_set("androidboot.flash.locked", "0");
 	proc_cmdline_set("androidboot.warranty_bit", "0");
 	proc_cmdline_set("androidboot.fmp_config", "1");
 


### PR DESCRIPTION
following this
[https://source.android.com/docs/core/architecture/bootloader/locking_unlocking](https://source.android.com/docs/core/architecture/bootloader/locking_unlocking)

I was trying to build E os, till I found out, I was oem was locked again, adding this line will force OEM unlock  tested by myself, I force to show OEM unlock option , and it was on and it will prevent user from disabling it even if you show it in developer option

the point is, if the rom need this, then it will do the oem unlock
if the rom doesnt need this option, still no harm done for these generation of devices 